### PR TITLE
Fix issue #11106, make others comment could be copied.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where recently opened files were not displayed in the main menu properly. [#9042](https://github.com/JabRef/jabref/issues/9042)
 - We fixed an issue where the DOI lookup would show an error when a DOI was found for an entry. [#11850](https://github.com/JabRef/jabref/issues/11850)
 - We fixed an issue where <kbd>Tab</kbd> cannot be used to jump to next field in some single-line fields. [#11785](https://github.com/JabRef/jabref/issues/11785)
+- We fixed an issue where allow selecting content of other user's comments.[#11106](https://github.com/JabRef/jabref/issues/11106)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/entryeditor/CommentsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/CommentsTab.java
@@ -13,6 +13,7 @@ import javax.swing.undo.UndoManager;
 import javafx.collections.ObservableList;
 import javafx.geometry.VPos;
 import javafx.scene.control.Button;
+import javafx.scene.control.TextInputControl;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.RowConstraints;
 
@@ -20,6 +21,7 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.autocompleter.SuggestionProviders;
 import org.jabref.gui.fieldeditors.FieldEditorFX;
 import org.jabref.gui.fieldeditors.FieldNameLabel;
+import org.jabref.gui.fieldeditors.MarkdownEditor;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.theme.ThemeManager;
@@ -98,6 +100,7 @@ public class CommentsTab extends FieldsEditorTab {
                         || field.getName().toLowerCase().contains("comment"))
                 .sorted(Comparator.comparing(Field::getName))
                 .collect(Collectors.toCollection(LinkedHashSet::new)));
+
         return comments;
     }
 
@@ -140,7 +143,8 @@ public class CommentsTab extends FieldsEditorTab {
             boolean isStandardBibtexComment = field == StandardField.COMMENT;
             boolean isDefaultOwnerComment = field.equals(userSpecificCommentField);
             boolean shouldBeEnabled = isStandardBibtexComment || isDefaultOwnerComment;
-            editor.getNode().setDisable(!shouldBeEnabled);
+            ((MarkdownEditor)editor.getNode()).setEditable(shouldBeEnabled);
+
         }
 
         // Show "Hide" button only if user-specific comment field is empty. Otherwise, it is a strange UI, because the

--- a/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
@@ -72,4 +72,8 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
     public void requestFocus() {
         textInput.requestFocus();
     }
+
+    public void setEditable(boolean isEditable){
+        textInput.setEditable(isEditable);
+    }
 }


### PR DESCRIPTION
Closes #11106

Allow selecting content of other user's comments.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
